### PR TITLE
feat: add light/dark theme toggle with system-preference default

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="dark">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -23,6 +23,17 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
     <link rel="preload" as="image" href="/frevo.webp" />
     <meta name="theme-color" content="#0f1117" />
+    <script>
+      (function () {
+        const stored = localStorage.getItem('theme');
+        const isDark = stored ? stored === 'dark' : window.matchMedia('(prefers-color-scheme: dark)').matches;
+        document.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light');
+        const metaThemeColor = document.querySelector('meta[name="theme-color"]');
+        if (metaThemeColor) {
+          metaThemeColor.setAttribute('content', isDark ? '#0f1117' : '#f8f7f2');
+        }
+      })();
+    </script>
     <title>Felipe Vasconcelos (f@avasconcelos.com)</title>
   </head>
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,10 @@
       "name": "avasconcelos.com",
       "version": "2.0.0",
       "dependencies": {
+        "clsx": "2.1.1",
         "react": "19.2.7",
-        "react-dom": "19.2.7"
+        "react-dom": "19.2.7",
+        "tailwind-merge": "3.6.0"
       },
       "devDependencies": {
         "@tailwindcss/vite": "4.3.2",
@@ -2881,6 +2883,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -3653,6 +3664,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
     "check": "npm run fmt:check && npm run lint"
   },
   "dependencies": {
+    "clsx": "2.1.1",
     "react": "19.2.7",
-    "react-dom": "19.2.7"
+    "react-dom": "19.2.7",
+    "tailwind-merge": "3.6.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "4.3.2",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,11 @@
 import { Content } from '@/components/content';
+import { ThemeToggle } from '@/components/theme-toggle';
 
 export function App() {
-  return <Content />;
+  return (
+    <>
+      <ThemeToggle />
+      <Content />
+    </>
+  );
 }

--- a/src/components/about.tsx
+++ b/src/components/about.tsx
@@ -1,4 +1,5 @@
 import { useLocale } from '@/i18n/use-locale';
+import { cn } from '@/utils/cn';
 
 export function About() {
   const { messages } = useLocale();
@@ -10,7 +11,7 @@ export function About() {
         <h2 className="text-accent text-xs font-semibold tracking-[0.2em] uppercase">{about.title}</h2>
       </div>
       {about.paragraphs.map((paragraph, index) => (
-        <p key={index} className={`reveal text-text-muted text-base leading-relaxed sm:text-lg ${index === 0 ? 'mt-6' : 'mt-4'}`}>
+        <p key={index} className={cn('reveal text-text-muted text-base leading-relaxed sm:text-lg', index === 0 ? 'mt-6' : 'mt-4')}>
           {paragraph}
         </p>
       ))}

--- a/src/components/experience.tsx
+++ b/src/components/experience.tsx
@@ -1,4 +1,5 @@
 import { useLocale } from '@/i18n/use-locale';
+import { cn } from '@/utils/cn';
 
 export function Experience() {
   const { messages } = useLocale();
@@ -11,7 +12,7 @@ export function Experience() {
       </div>
       <div className="mt-8 space-y-12">
         {experience.roles.map((role, i) => (
-          <article key={role.company} className={i % 2 === 0 ? 'reveal-left' : 'reveal-right'}>
+          <article key={role.company} className={cn(i % 2 === 0 ? 'reveal-left' : 'reveal-right')}>
             <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
               <h3 className="text-text text-lg font-semibold">{role.company}</h3>
               <span className="text-text-muted text-sm whitespace-nowrap italic">{role.period}</span>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -22,7 +22,7 @@ export function Hero() {
       {/* Gradient overlay for text readability */}
       <div className="from-bg/60 via-bg/40 to-bg dark:from-bg/60 dark:via-bg/40 absolute inset-0 bg-gradient-to-b" aria-hidden="true" />
 
-      <div className="relative z-10">
+      <div className="text-shadow relative z-10">
         <p className="reveal text-text-muted mb-4 text-sm tracking-widest uppercase">{hero.role}</p>
         <h1 className="reveal text-4xl leading-[1.1] font-bold tracking-tight sm:text-5xl md:text-6xl lg:text-7xl">Felipe Vasconcelos</h1>
         <div className="reveal from-accent via-vermillion mt-6 h-[2px] w-24 bg-gradient-to-r to-transparent" />

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -17,10 +17,10 @@ export function Hero() {
       {/* Frevo background — faded, atmospheric, randomly selected */}
       <picture className="absolute inset-0" aria-hidden="true">
         <source srcSet={image.webp} type="image/webp" />
-        <img src={image.jpg} alt="" width="1920" height="1080" className="h-full w-full object-cover opacity-[0.16] dark:opacity-[0.12]" loading="eager" decoding="async" />
+        <img src={image.jpg} alt="" width="1920" height="1080" className="h-full w-full object-cover opacity-[0.30] dark:opacity-[0.12]" loading="eager" decoding="async" />
       </picture>
       {/* Gradient overlay for text readability */}
-      <div className="from-bg/75 via-bg/55 to-bg dark:from-bg/60 dark:via-bg/40 absolute inset-0 bg-gradient-to-b" aria-hidden="true" />
+      <div className="from-bg/60 via-bg/40 to-bg dark:from-bg/60 dark:via-bg/40 absolute inset-0 bg-gradient-to-b" aria-hidden="true" />
 
       <div className="relative z-10">
         <p className="reveal text-text-muted mb-4 text-sm tracking-widest uppercase">{hero.role}</p>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -13,10 +13,10 @@ export function Hero() {
       {/* Frevo background — faded, atmospheric, randomly selected */}
       <picture className="absolute inset-0" aria-hidden="true">
         <source srcSet={image.webp} type="image/webp" />
-        <img src={image.jpg} alt="" width="1920" height="1080" className="h-full w-full object-cover opacity-[0.12]" loading="eager" decoding="async" />
+        <img src={image.jpg} alt="" width="1920" height="1080" className="h-full w-full object-cover opacity-[0.08] dark:opacity-[0.12]" loading="eager" decoding="async" />
       </picture>
-      {/* Dark gradient overlay for text readability */}
-      <div className="from-bg/60 via-bg/40 to-bg absolute inset-0 bg-gradient-to-b" aria-hidden="true" />
+      {/* Gradient overlay for text readability */}
+      <div className="from-bg/80 via-bg/60 to-bg dark:from-bg/60 dark:via-bg/40 absolute inset-0 bg-gradient-to-b" aria-hidden="true" />
 
       <div className="relative z-10">
         <p className="reveal text-text-muted mb-4 text-sm tracking-widest uppercase">Senior Software Engineer</p>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -17,17 +17,17 @@ export function Hero() {
       {/* Frevo background — faded, atmospheric, randomly selected */}
       <picture className="absolute inset-0" aria-hidden="true">
         <source srcSet={image.webp} type="image/webp" />
-        <img src={image.jpg} alt="" width="1920" height="1080" className="h-full w-full object-cover opacity-[0.08] dark:opacity-[0.12]" loading="eager" decoding="async" />
+        <img src={image.jpg} alt="" width="1920" height="1080" className="h-full w-full object-cover opacity-[0.16] dark:opacity-[0.12]" loading="eager" decoding="async" />
       </picture>
       {/* Gradient overlay for text readability */}
-      <div className="from-bg/80 via-bg/60 to-bg dark:from-bg/60 dark:via-bg/40 absolute inset-0 bg-gradient-to-b" aria-hidden="true" />
+      <div className="from-bg/75 via-bg/55 to-bg dark:from-bg/60 dark:via-bg/40 absolute inset-0 bg-gradient-to-b" aria-hidden="true" />
 
       <div className="relative z-10">
         <p className="reveal text-text-muted mb-4 text-sm tracking-widest uppercase">{hero.role}</p>
         <h1 className="reveal text-4xl leading-[1.1] font-bold tracking-tight sm:text-5xl md:text-6xl lg:text-7xl">Felipe Vasconcelos</h1>
         <div className="reveal from-accent via-vermillion mt-6 h-[2px] w-24 bg-gradient-to-r to-transparent" />
         <p className="reveal text-text-muted mt-6 max-w-xl text-base leading-relaxed sm:text-lg">{hero.tagline}</p>
-        <p className="reveal text-accent/70 mt-3 text-sm italic">{hero.quote}</p>
+        <p className="reveal text-accent dark:text-accent/70 mt-3 text-sm italic">{hero.quote}</p>
         <div className="reveal text-text-muted mt-8 flex items-center justify-center gap-2 text-sm">
           <span>{hero.location}</span>
           <span className="bg-accent/50 h-1 w-1 rounded-full" />

--- a/src/components/language-switcher.tsx
+++ b/src/components/language-switcher.tsx
@@ -16,7 +16,7 @@ export function LanguageSwitcher() {
               onClick={() => setLocale(code)}
               aria-pressed={active}
               className={`rounded-full px-3 py-1 text-xs font-medium transition-colors duration-200 ${
-                active ? 'bg-accent/15 text-accent ring-accent/50 ring-1' : 'text-text-muted hover:text-text hover:bg-white/5'
+                active ? 'bg-accent/15 text-accent ring-accent/50 ring-1' : 'text-text-muted hover:text-text hover:bg-text/5'
               }`}
             >
               {code.toUpperCase()}

--- a/src/components/language-switcher.tsx
+++ b/src/components/language-switcher.tsx
@@ -1,5 +1,6 @@
 import { SUPPORTED_LOCALES } from '@/i18n/types';
 import { useLocale } from '@/i18n/use-locale';
+import { cn } from '@/utils/cn';
 
 export function LanguageSwitcher() {
   const { locale, setLocale, messages } = useLocale();
@@ -15,9 +16,10 @@ export function LanguageSwitcher() {
               type="button"
               onClick={() => setLocale(code)}
               aria-pressed={active}
-              className={`rounded-full px-3 py-1 text-xs font-medium transition-colors duration-200 ${
-                active ? 'bg-accent/15 text-accent ring-accent/50 ring-1' : 'text-text-muted hover:text-text hover:bg-text/5'
-              }`}
+              className={cn(
+                'rounded-full px-3 py-1 text-xs font-medium transition-colors duration-200',
+                active ? 'bg-accent/15 text-accent ring-1 ring-accent/50' : 'text-text-muted hover:bg-text/5 hover:text-text',
+              )}
             >
               {code.toUpperCase()}
             </button>

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,65 @@
+import { useTheme } from '@/hooks/use-theme';
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  const isDark = theme === 'dark';
+  const label = isDark ? 'Switch to light theme' : 'Switch to dark theme';
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      aria-label={label}
+      title={label}
+      className="border-border bg-surface text-text hover:border-accent hover:text-accent focus-visible:ring-accent fixed top-4 right-4 z-50 flex h-11 w-11 items-center justify-center rounded-full border shadow-sm transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+    >
+      {isDark ? <SunIcon /> : <MoonIcon />}
+    </button>
+  );
+}
+
+function SunIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2" />
+      <path d="M12 20v2" />
+      <path d="m4.93 4.93 1.41 1.41" />
+      <path d="m17.66 17.66 1.41 1.41" />
+      <path d="M2 12h2" />
+      <path d="M20 12h2" />
+      <path d="m6.34 17.66-1.41 1.41" />
+      <path d="m19.07 4.93-1.41 1.41" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+    </svg>
+  );
+}

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -11,7 +11,7 @@ export function ThemeToggle() {
       onClick={toggleTheme}
       aria-label={label}
       title={label}
-      className="border-border bg-surface text-text hover:border-accent hover:text-accent focus-visible:ring-accent fixed top-4 right-4 z-50 flex h-11 w-11 items-center justify-center rounded-full border shadow-sm transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+      className="border-border bg-surface text-text hover:border-accent hover:text-accent focus-visible:ring-accent fixed top-16 right-4 z-50 flex h-11 w-11 items-center justify-center rounded-full border shadow-sm transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
     >
       {isDark ? <SunIcon /> : <MoonIcon />}
     </button>

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'theme';
+type Theme = 'light' | 'dark';
+
+function getSystemTheme(): Theme {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function getStoredTheme(): Theme | null {
+  try {
+    const value = localStorage.getItem(STORAGE_KEY);
+    return value === 'light' || value === 'dark' ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function applyTheme(theme: Theme): void {
+  document.documentElement.setAttribute('data-theme', theme);
+  try {
+    localStorage.setItem(STORAGE_KEY, theme);
+  } catch {
+    // Ignore storage errors (e.g. private mode).
+  }
+}
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>(() => getStoredTheme() ?? getSystemTheme());
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((current) => (current === 'dark' ? 'light' : 'dark'));
+  }, []);
+
+  return { theme, toggleTheme };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,14 +1,40 @@
 @import 'tailwindcss';
 
-@theme {
-  --color-bg: #0f1117;
-  --color-surface: #1a1d26;
-  --color-accent: #c9a84c;
-  --color-accent-dim: #a68a3a;
-  --color-vermillion: #c23b22;
-  --color-text: #e2e8f0;
-  --color-text-muted: #94a3b8;
-  --color-border: #2d3348;
+@custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
+
+:root {
+  --bg: #f8f7f2;
+  --surface: #ffffff;
+  --accent: #b08d28;
+  --accent-dim: #8f7320;
+  --vermillion: #c23b22;
+  --text: #1a1a1a;
+  --text-muted: #6b6b6b;
+  --border: #e0dcd0;
+  color-scheme: light;
+}
+
+[data-theme='dark'] {
+  --bg: #0f1117;
+  --surface: #1a1d26;
+  --accent: #c9a84c;
+  --accent-dim: #a68a3a;
+  --vermillion: #c23b22;
+  --text: #e2e8f0;
+  --text-muted: #94a3b8;
+  --border: #2d3348;
+  color-scheme: dark;
+}
+
+@theme inline {
+  --color-bg: var(--bg);
+  --color-surface: var(--surface);
+  --color-accent: var(--accent);
+  --color-accent-dim: var(--accent-dim);
+  --color-vermillion: var(--vermillion);
+  --color-text: var(--text);
+  --color-text-muted: var(--text-muted);
+  --color-border: var(--border);
 }
 
 * {
@@ -24,7 +50,6 @@ body,
 #root {
   width: 100%;
   min-height: 100%;
-  color-scheme: dark;
 }
 
 body {
@@ -55,7 +80,7 @@ h6 {
 
 ::selection {
   background-color: var(--color-accent);
-  color: #0f1117;
+  color: var(--bg);
 }
 
 /* ── Focus states ───────────────────────────────────────── */

--- a/src/index.css
+++ b/src/index.css
@@ -5,8 +5,8 @@
 :root {
   --bg: #f8f7f2;
   --surface: #ffffff;
-  --accent: #b08d28;
-  --accent-dim: #8f7320;
+  --accent: #7a5a00;
+  --accent-dim: #5e4500;
   --vermillion: #c23b22;
   --text: #1a1a1a;
   --text-muted: #6b6b6b;

--- a/src/index.css
+++ b/src/index.css
@@ -78,6 +78,10 @@ h6 {
   text-wrap: balance;
 }
 
+@utility text-shadow {
+  text-shadow: 0 1px 2px var(--bg);
+}
+
 ::selection {
   background-color: var(--color-accent);
   color: var(--bg);

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Summary

- Adds a light theme to the site alongside the existing dark theme.
- Adds a fixed top-right light/dark toggle.
- Defaults to the user’s system preference (`prefers-color-scheme`) and persists an explicit choice in `localStorage`.
- Updates CSS tokens to use Tailwind CSS v4 `@theme inline` with a custom `data-theme` dark variant.
- Adjusts the hero image/overlay for light mode.

## Changes

- `src/hooks/use-theme.ts` — theme state, system-preference fallback, localStorage persistence.
- `src/components/theme-toggle.tsx` — accessible toggle button.
- `src/index.css` — light/dark token sets.
- `index.html` — inline theme initializer to prevent FOUC.
- `src/app.tsx` — integrates the toggle.
- `src/components/hero.tsx` — light-mode image opacity and overlay.

## Validation

- `npm run check` passes.
- `npm run build` passes.